### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ on:
 
 jobs:
   build-debug-apk:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 20


### PR DESCRIPTION
Potential fix for [https://github.com/thejaustin/AutoCat/security/code-scanning/1](https://github.com/thejaustin/AutoCat/security/code-scanning/1)

To fix the problem, add a `permissions` block specifying minimal required permissions for the `build-debug-apk` job. Since the job only checks out the code, installs dependencies, builds, and uploads an artifact, it only needs `contents: read`. Add:
```yaml
permissions:
  contents: read
```
immediately under the job name (i.e., right after `build-debug-apk:` or after `runs-on:`—either is acceptable, but directly after the job name is typical).

No new methods, imports, or changes to individual steps are necessary beyond this insertion. Add only for the `build-debug-apk` job; all other jobs can be left unchanged, as the `autocat-release` job already declares its required permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
